### PR TITLE
Add Helm v3 to params

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ jobs:
         uses: stefanprodan/kube-tools@v1
         with:
           kubectl: 1.16.2
-          kustomize: 3.2.3
-          helm: 2.14.3
+          kustomize: 3.4.0
+          helm: 2.16.1
+          helmv3: 3.0.0
           command: |
             echo "Run conftest"
             kustomize build test/kustomize | conftest test -p test/policy -

--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,11 @@ inputs:
   kubectl:
     description: 'kubectl version e.g. 1.16.0'
   kustomize:
-    description: 'kustomize version e.g. 3.2.3'
+    description: 'kustomize version e.g. 3.4.0'
   helm:
-    description: 'helm version e.g. 2.14.3'
-
+    description: 'helm version e.g. 2.16.1'
+  helmv3:
+    description: 'helm version e.g. 3.0.0'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -11,14 +11,20 @@ fi
 
 KUSTOMIZE_VER=$3
 if [[ "${KUSTOMIZE_VER}" != "" ]]; then
-  curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VER}/kustomize_kustomize.v${KUSTOMIZE_VER}_linux_amd64 \
-  -o /usr/local/bin/kustomize && chmod +x /usr/local/bin/kustomize
+  curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VER}/kustomize_v${KUSTOMIZE_VER}_linux_amd64.tar.gz | \
+  tar xz && mv kustomize /usr/local/bin/kustomize
 fi
 
 HELM_VER=$4
 if [[ "${HELM_VER}" != "" ]]; then
   curl -sL https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz | \
   tar xz && mv linux-amd64/helm /usr/local/bin/helm && rm -rf linux-amd64
+fi
+
+HELM3_VER=$4
+if [[ "${HELM_VER}" != "" ]]; then
+  curl -sL https://get.helm.sh/helm-v${HELM3_VER}-linux-amd64.tar.gz | \
+  tar xz && mv linux-amd64/helm /usr/local/bin/helmv3 && rm -rf linux-amd64
 fi
 
 echo ">>> Executing command <<<"

--- a/src/install.sh
+++ b/src/install.sh
@@ -8,19 +8,19 @@ curl -sL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL}/b
 -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 kubectl version --client
 
-KUSTOMIZE=3.2.3
+KUSTOMIZE=3.4.0
 echo "downloading kustomize ${KUSTOMIZE}"
-curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE}/kustomize_kustomize.v${KUSTOMIZE}_linux_amd64 \
--o /usr/local/bin/kustomize && chmod +x /usr/local/bin/kustomize
+curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE}/kustomize_v${KUSTOMIZE}_linux_amd64.tar.gz | \
+tar xz && mv kustomize /usr/local/bin/kustomize
 kustomize version
 
-HELM_V2=2.14.3
+HELM_V2=2.16.1
 echo "downloading helm ${HELM_V2}"
 curl -sSL https://get.helm.sh/helm-v${HELM_V2}-linux-amd64.tar.gz | \
 tar xz && mv linux-amd64/helm /usr/local/bin/helm && rm -rf linux-amd64
 helm version --client
 
-HELM_V3=3.0.0-beta.5
+HELM_V3=3.0.0
 echo "downloading helm ${HELM_V3}"
 curl -sSL https://get.helm.sh/helm-v${HELM_V3}-linux-amd64.tar.gz | \
 tar xz && mv linux-amd64/helm /usr/local/bin/helmv3 && rm -rf linux-amd64
@@ -32,7 +32,7 @@ curl -sL https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL}/kub
 tar xz && mv kubeval /usr/local/bin/kubeval
 kubeval --version
 
-CONFTEST=0.14.0
+CONFTEST=0.15.0
 echo "downloading conftest ${CONFTEST}"
 curl -sL https://github.com/instrumenta/conftest/releases/download/v${CONFTEST}/conftest_${CONFTEST}_Linux_x86_64.tar.gz | \
 tar xz && mv conftest /usr/local/bin/conftest


### PR DESCRIPTION
This PR adds the `helmv3` param and updates tools:
* helm 2.16.1
* helmv3 3.0.0
* kustomize: 3.4.0
* conftest 0.15.0