### PR TITLE
trimming docker fat and using shell over bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM golang:1.13
+FROM alpine:3.10 as build
 
-COPY LICENSE README.md /
-COPY src/ /
+RUN apk --no-cache add curl
+
+COPY src/install.sh /
+
 RUN /install.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+# use busybox for a smaller, simple, entrypoint for scripting
+FROM busybox:1.31
+
+COPY --from=build /usr/local/bin /usr/local/bin
+
+ENV PATH "/usr/local/bin"
+
+CMD /bin/sh

--- a/src/install.sh
+++ b/src/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -o errexit
 


### PR DESCRIPTION
docker image goes from 995MB -> to 194MB
attack surface & scope greatly reduced
switched `install.sh` to shell for alpine