### PR TITLE
Enabled to operate the version of kubeval

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ jobs:
           helm: 2.16.7
           helmv3: 3.2.1
           kubeseal: 0.12.5
+          kubeval: v0.16.1
           kubeaudit: 0.11.5
           command: |
             echo "Run conftest"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -33,6 +33,12 @@ if [[ "${KUBESEAL_VER}" != "" ]]; then
   -o /usr/local/bin/kubeseal && chmod +x /usr/local/bin/kubeseal
 fi
 
+KUBEVAL_VER=$7
+if [[ "${KUBEVAL_VER}" != "" ]]; then
+  curl -sL https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VER}/kubeval-linux-amd64.tar.gz | \
+  tar xz && mv kubeval /usr/local/bin/kubeval
+fi
+
 echo ">>> Executing command <<<"
 echo ""
 echo ""


### PR DESCRIPTION
Hi. I want to use the new version of kubeval, so I made it possible to change the version of kubeval with an argument like other tools.

I have confirmed that the github actions I use in my project behave as intended.

here is my workflow.
```
- name: Run Kubernetes tools
      uses: wadason/kube-tools@add-kubeval-to-entrypoint
      with:
        kubectl: 1.18.2
        kustomize: 3.8.5
        kubeval: v0.16.1
        command: |
          echo "Run kubeval"
          kubeval --version
```

and here is output.
<img width="340" alt="スクリーンショット 2021-05-27 18 16 39" src="https://user-images.githubusercontent.com/27562705/119800165-b8c4f280-bf17-11eb-9e54-02275d65d502.png">
