### PR TITLE
Enable to pass `conftest` version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,8 @@ inputs:
     description: 'kubeaudit version'
   kubeval:
     description: 'kubeval version'
+  conftest:
+    description: 'conftest version'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -32,4 +34,5 @@ runs:
     - ${{ inputs.helm }}
     - ${{ inputs.helmv3 }}
     - ${{ inputs.kubeseal }}
-    - ${{ inputs.kubeval }}    
+    - ${{ inputs.kubeval }}
+    - ${{ inputs.conftest }}

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -39,6 +39,12 @@ if [[ "${KUBEVAL_VER}" != "" ]]; then
   tar xz && mv kubeval /usr/local/bin/kubeval
 fi
 
+CONFTEST_VER=$8
+if [[ "${CONFTEST_VER}" != "" ]]; then
+  wget -O conftest https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VER}/conftest_${CONFTEST_VER}_Linux_x86_64.tar.gz -q
+  tar xzf conftest && mv conftest /usr/local/bin
+fi
+
 echo ">>> Executing command <<<"
 echo ""
 echo ""


### PR DESCRIPTION
Hi,
`confest` is missing in inputs, so we can't pass version to Github Actions for now.