### PR TITLE
feat: add `kubeconform` package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,8 @@ inputs:
     description: 'kubeval version'
   conftest:
     description: 'conftest version'
+  kubeconform:
+    description: 'kubeconform version'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -36,3 +38,4 @@ runs:
     - ${{ inputs.kubeseal }}
     - ${{ inputs.kubeval }}
     - ${{ inputs.conftest }}
+    - ${{ inputs.kubeconform }}

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -45,6 +45,12 @@ if [[ "${CONFTEST_VER}" != "" ]]; then
   tar xzf conftest && mv conftest /usr/local/bin
 fi
 
+KUBECONFORM_VER=$9
+if [[ "${KUBECONFORM_VER}" != "" ]]; then
+  curl -sSL https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VER}/kubeconform-linux-amd64.tar.gz | \
+  tar xz && mv kubeconform /usr/local/bin/kubeconform
+fi
+
 echo ">>> Executing command <<<"
 echo ""
 echo ""

--- a/src/install.sh
+++ b/src/install.sh
@@ -59,3 +59,9 @@ echo "downloading jq"
 curl -sL https://github.com/stedolan/jq/releases/latest/download/jq-linux64 \
 -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq
 jq --version
+
+KUBECONFORM="v0.4.12"
+echo "downloading kubeconform ${KUBECONFORM}"
+curl -sSL https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM}/kubeconform-linux-amd64.tar.gz | \
+tar xz && mv kubeconform /usr/local/bin/kubeconform
+kubeconform --help


### PR DESCRIPTION
https://github.com/yannh/kubeconform

this package can be used as a relatively easy drop-in replacement for `kubeval` which hasn't updated its `kubernetes-json-schema` since 2020-04-29.

ref:
https://github.com/instrumenta/kubernetes-json-schema