### PR TITLE
Removes embedded v in yq version

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -53,7 +53,7 @@ fi
 
 YQ_VER=${10}
 if [[ "${YQ_VER}" != "" ]]; then
-  curl -sL https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_amd64 \
+  curl -sL https://github.com/mikefarah/yq/releases/download/${YQ_VER}/yq_linux_amd64 \
   -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 fi
 

--- a/src/install.sh
+++ b/src/install.sh
@@ -56,9 +56,9 @@ curl -sSL https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM}
 tar xz && mv kubeconform /usr/local/bin/kubeconform
 kubeconform --help
 
-YQ=4.16.1
+YQ=v4.18.1
 echo "downloading yq"
-curl -sL https://github.com/mikefarah/yq/releases/download/v${YQ}/yq_linux_amd64 \
+curl -sL https://github.com/mikefarah/yq/releases/download/${YQ}/yq_linux_amd64 \
 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 yq --version
 


### PR DESCRIPTION
Prefixing the "v" into the yq version limits what version we may use. It appears yq has only started using the `vX.X.X` starting in `v4`. Everything prior just used a version number.

See https://github.com/mikefarah/yq/releases & https://github.com/mikefarah/yq/releases/tag/3.4.1

I'm happy to add a callout in the README as well.